### PR TITLE
Introduce the <sample_group> place holder.

### DIFF
--- a/lib/bio/pipengine/job.rb
+++ b/lib/bio/pipengine/job.rb
@@ -161,14 +161,28 @@ module Bio
 				tmp_cmd = cmd.gsub(/<sample>/,sample.name)
 				if tmp_cmd =~/<sample_path>/
 					sample_path_glob = (tmp_cmd.scan(/<sample_path>(\S+)/).map {|e| e.first})
-					if sample_path_glob.empty?
-						tmp_cmd.gsub!(/<sample_path>/,sample.path.join("\s"))
-					else
+					unless sample_path_glob.empty?
 						sample_path_glob.each do |append|
 							tmp_cmd.gsub!(/<sample_path>#{Regexp.quote(append)}/,(sample.path.map {|s| s+append}).join("\s"))
 						end
 					end
+					tmp_cmd.gsub!(/<sample_path>/,sample.path.join("\s"))
 				end
+
+				if tmp_cmd =~/<sample_group>/
+					sample_group_glob = (tmp_cmd.scan(/<sample_group>(\S+)/).map {|e| e.first})
+					unless sample_group_glob.empty?
+						sample_group_glob.each do |append|
+							tmp_cmd.gsub!(/<sample_group>#{Regexp.quote(append)}/,(sample.group+append))
+						end
+					end
+					tmp_cmd.gsub!(/<sample_group>/,sample.group)
+				end
+
+				if tmp_cmd =~/<sample_group\/>/
+					tmp_cmd = tmp_cmd.gsub(/<sample_group\/>/,self.output+"/")
+				end
+
 				# for resourcers and cpus
 				tmp_cmd = sub_resources_and_cpu(tmp_cmd,step)
 				


### PR DESCRIPTION
Fix a bug with the processing of the <sample_path> when there are multiple instances
I suspect that if there are multiple <sample_path> <sample_path>SomethingAttached
only the second placeholder will be subsituted, the first one will not.
for <sample_group> I changed using the unless and try to substitute for the simpler placeholder
in any case.